### PR TITLE
Feature/1 store twitter creds

### DIFF
--- a/smolblog-social.php
+++ b/smolblog-social.php
@@ -38,3 +38,8 @@ add_action( 'plugins_loaded', function() {
 		} );
 	}
 } );
+
+register_activation_hook( __FILE__, function() {
+	$db = new Database\Schema();
+	$db->create_social_table();
+} );

--- a/src/AdminPage/AdminPageRegistrar.php
+++ b/src/AdminPage/AdminPageRegistrar.php
@@ -1,0 +1,68 @@
+<?php //phpcs:ignore Wordpress.Files.Filename
+/**
+ * Admin page Registrar for the plugin
+ *
+ * @author  Evan Hildreth <me@eph.me>
+ * @since   0.1.0
+ * @package Smolblog\Social
+ */
+
+namespace Smolblog\Social\AdminPage;
+
+use WebDevStudios\OopsWP\Structure\Service;
+use WebDevStudios\OopsWP\Utility\Hookable;
+
+/**
+ * Registrar class to register our custom post types
+ *
+ * @since 0.1.0
+ */
+class AdminPageRegistrar extends Service {
+
+	/**
+	 * List of Hookable classes that should be registered
+	 * by this service
+	 *
+	 * @var Array $pages array of Hookable classes
+	 * @since 0.1.0
+	 */
+	protected $pages = [
+		SmolblogMain::class,
+	];
+
+	/**
+	 * Called by Plugin class; register the hooks for this plugin
+	 *
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 */
+	public function register_hooks() {
+		add_action( 'init', [ $this, 'register_pages' ] );
+	}
+
+	/**
+	 * Iterate through $pages and register them.
+	 *
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 */
+	public function register_pages() {
+		foreach ( $this->pages as $page_class ) {
+			$page = new $page_class();
+			$this->register_page( $page );
+		}
+	}
+
+	/**
+	 * Register the given instantiated content class. This function
+	 * largely exists as a check to make sure we are passing the correct
+	 * object class.
+	 *
+	 * @param Hookable $page Endpoint to register.
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 */
+	private function register_page( Hookable $page ) {
+		$page->register_hooks();
+	}
+}

--- a/src/AdminPage/SmolblogMain.php
+++ b/src/AdminPage/SmolblogMain.php
@@ -32,7 +32,7 @@ class SmolblogMain implements Hookable {
 		add_menu_page(
 			'Smolblog Dashboard',
 			'Smolblog',
-			'manage_options',
+			'read',
 			'smolblog',
 			[ $this, 'smolblog_dashboard' ],
 			'dashicons-controls-repeat',
@@ -49,8 +49,8 @@ class SmolblogMain implements Hookable {
 		$table_name   = $wpdb->prefix . 'smolblog_social';
 		$all_accounts = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT * FROM $table_name", // WHERE user_id = %d", //phpcs:ignore
-				// get_current_user_id(),
+				"SELECT * FROM $table_name WHERE user_id = %d", //phpcs:ignore
+				get_current_user_id(),
 			)
 		);
 ?>
@@ -64,7 +64,7 @@ class SmolblogMain implements Hookable {
 		<?php endforeach; ?>
 		</ul>
 
-		<p>Add new account: <a href="<?php echo get_rest_url( null, 'smolblog/v1/twitter/init' ); ?>" class="button">Sign in with Twitter</a></p>
+		<p>Add new account: <a href="<?php echo get_rest_url( null, 'smolblog/v1/twitter/init' ); ?>?_wpnonce=<?php echo wp_create_nonce( 'wp_rest' ); ?>" class="button">Sign in with Twitter</a></p>
 
 		<p>Twitter callback: <code><?php echo get_rest_url( null, 'smolblog/v1/twitter/callback' ); ?></code></p>
 <?php

--- a/src/AdminPage/SmolblogMain.php
+++ b/src/AdminPage/SmolblogMain.php
@@ -44,21 +44,27 @@ class SmolblogMain implements Hookable {
 	 * Output the Smolblog dashboard page
 	 */
 	public function smolblog_dashboard() {
+		global $wpdb;
+
+		$table_name   = $wpdb->prefix . 'smolblog_social';
+		$all_accounts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM $table_name", // WHERE user_id = %d", //phpcs:ignore
+				// get_current_user_id(),
+			)
+		);
 ?>
 		<h1>Smolblog</h1>
 
-		<?php if ( ! empty ( $_GET['smolblog_action'] ) && 'import_twitter' === $_GET['smolblog_action'] ) : ?>
-			<h2>Twitter import</h2>
-			<pre>
-			Not yet!
-			</pre>
-		<?php elseif ( get_option( 'smolblog_twitter_username' ) ) : ?>
-			<p>Authenticated with Twitter as <?php echo esc_html( get_option( 'smolblog_twitter_username' ) ); ?></p>
+		<h2>Connected social accounts:</h2>
 
-			<p><a href="?page=smolblog&amp;smolblog_action=import_twitter" class="button">Import latest 10 tweets</a>
-		<?php else : ?>
-			<p><a href="<?php echo get_rest_url( null, 'smolblog/v1/twitter/init' ); ?>" class="button">Sign in with Twitter</a></p>
-		<?php endif; ?>
+		<ul>
+		<?php foreach ( $all_accounts as $account ) : ?>
+			<li><strong>Twitter:</strong> <?php echo $account->social_username; ?></li>
+		<?php endforeach; ?>
+		</ul>
+
+		<p>Add new account: <a href="<?php echo get_rest_url( null, 'smolblog/v1/twitter/init' ); ?>" class="button">Sign in with Twitter</a></p>
 
 		<p>Twitter callback: <code><?php echo get_rest_url( null, 'smolblog/v1/twitter/callback' ); ?></code></p>
 <?php

--- a/src/AdminPage/SmolblogMain.php
+++ b/src/AdminPage/SmolblogMain.php
@@ -1,0 +1,66 @@
+<?php //phpcs:ignore Wordpress.Files.Filename
+/**
+ * Main admin page for this plugin
+ *
+ * @author  Evan Hildreth <me@eph.me>
+ * @since   0.1.0
+ * @package Smolblog\Social
+ */
+
+namespace Smolblog\Social\AdminPage;
+
+use WebDevStudios\OopsWP\Utility\Hookable;
+
+/**
+ * Registrar class to register our custom post types
+ *
+ * @since 0.1.0
+ */
+class SmolblogMain implements Hookable {
+	/**
+	 * All the hooks my object sets up, right in one place!
+	 */
+	public function register_hooks() {
+			// Put your hooks here!
+			add_action( 'admin_menu', [ $this, 'add_smolblog_dashboard_page' ] );
+	}
+
+	/**
+	 * My init callback.
+	 */
+	public function add_smolblog_dashboard_page() {
+		add_menu_page(
+			'Smolblog Dashboard',
+			'Smolblog',
+			'manage_options',
+			'smolblog',
+			[ $this, 'smolblog_dashboard' ],
+			'dashicons-controls-repeat',
+			3
+		);
+	}
+
+	/**
+	 * Output the Smolblog dashboard page
+	 */
+	public function smolblog_dashboard() {
+?>
+		<h1>Smolblog</h1>
+
+		<?php if ( ! empty ( $_GET['smolblog_action'] ) && 'import_twitter' === $_GET['smolblog_action'] ) : ?>
+			<h2>Twitter import</h2>
+			<pre>
+			Not yet!
+			</pre>
+		<?php elseif ( get_option( 'smolblog_twitter_username' ) ) : ?>
+			<p>Authenticated with Twitter as <?php echo esc_html( get_option( 'smolblog_twitter_username' ) ); ?></p>
+
+			<p><a href="?page=smolblog&amp;smolblog_action=import_twitter" class="button">Import latest 10 tweets</a>
+		<?php else : ?>
+			<p><a href="<?php echo get_rest_url( null, 'smolblog/v1/twitter/init' ); ?>" class="button">Sign in with Twitter</a></p>
+		<?php endif; ?>
+
+		<p>Twitter callback: <code><?php echo get_rest_url( null, 'smolblog/v1/twitter/callback' ); ?></code></p>
+<?php
+	}
+}

--- a/src/Database/Schema.php
+++ b/src/Database/Schema.php
@@ -1,0 +1,56 @@
+<?php //phpcs:ignore Wordpress.Files.Filename
+/**
+ * Class Schema for Smolblog Social
+ *
+ * @author  Evan Hildreth <me@eph.me>
+ * @since   0.1.0
+ * @package Smolblog\Social
+ */
+
+namespace Smolblog\Social\Database;
+
+/**
+ * Create and maintain the custom database table for Smolblog
+ *
+ * @since 0.1.0
+ */
+class Schema {
+	/**
+	 * Version of the database defined in this file. Will be
+	 * checked against option `smolblog_social_db_version` to determine
+	 * if upgrade is needed.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @var int $db_version
+	 */
+	private $db_version = 1;
+
+	/**
+	 * Create table for storing social account information.
+	 *
+	 * @author Evan Hildreth <me@eph.me>
+	 * @since 0.1.0
+	 */
+	public function create_social_table() {
+		global $wpdb;
+
+		$table_name      = $wpdb->prefix . 'smolblog_social';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE $table_name (
+			id bigint(20) NOT NULL AUTO_INCREMENT,
+			user_id bigint(20) NOT NULL,
+			social_id varchar(50) NOT NULL,
+			social_username varchar(50) NOT NULL,
+			oauth_token varchar(255) NOT NULL,
+			oauth_secret varchar(255) NOT NULL, 
+			PRIMARY KEY  (id)
+		) $charset_collate;";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+
+		update_option( 'smolblog_social_db_version', $this->db_version );
+	}
+}

--- a/src/Endpoint/EndpointRegistrar.php
+++ b/src/Endpoint/EndpointRegistrar.php
@@ -27,6 +27,7 @@ class EndpointRegistrar extends Service {
 	 * @since 0.1.0
 	 */
 	protected $endpoints = [
+		TwitterInit::class,
 		TwitterCallback::class,
 	];
 

--- a/src/Endpoint/EndpointRegistrar.php
+++ b/src/Endpoint/EndpointRegistrar.php
@@ -1,0 +1,68 @@
+<?php //phpcs:ignore Wordpress.Files.Filename
+/**
+ * Endpoint Registrar for the plugin
+ *
+ * @author  Evan Hildreth <me@eph.me>
+ * @since   0.1.0
+ * @package Smolblog\Social
+ */
+
+namespace Smolblog\Social;
+
+use WebDevStudios\OopsWP\Structure\Service;
+use WebDevStudios\OopsWP\Structure\Content\ApiEndpoint;
+
+/**
+ * Registrar class to register our custom post types
+ *
+ * @since 0.1.0
+ */
+class EndpointRegistrar extends Service {
+
+	/**
+	 * List of ApiEndpoint classes that should be registered
+	 * by this service
+	 *
+	 * @var Array $endpoints array of ApiEndpoint classes
+	 * @since 0.1.0
+	 */
+	protected $endpoints = [
+		TwitterCallback::class,
+	];
+
+	/**
+	 * Called by Plugin class; register the hooks for this plugin
+	 *
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 */
+	public function register_hooks() {
+		add_action( 'rest_api_init', [ $this, 'register_endpoints' ] );
+	}
+
+	/**
+	 * Iterate through $endpoints and register them.
+	 *
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 */
+	public function register_endpoints() {
+		foreach ( $this->endpoints as $endpoint_class ) {
+			$endpoint = new $endpoint_class();
+			$this->register_endpoint( $endpoint );
+		}
+	}
+
+	/**
+	 * Register the given instantiated content class. This function
+	 * largely exists as a check to make sure we are passing the correct
+	 * object class.
+	 *
+	 * @param ApiEndpoint $endpoint Endpoint to register.
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 */
+	private function register_endpoint( ApiEndpoint $endpoint ) {
+		$endpoint->register();
+	}
+}

--- a/src/Endpoint/EndpointRegistrar.php
+++ b/src/Endpoint/EndpointRegistrar.php
@@ -7,7 +7,7 @@
  * @package Smolblog\Social
  */
 
-namespace Smolblog\Social;
+namespace Smolblog\Social\Endpoint;
 
 use WebDevStudios\OopsWP\Structure\Service;
 use WebDevStudios\OopsWP\Structure\Content\ApiEndpoint;

--- a/src/Endpoint/TwitterCallback.php
+++ b/src/Endpoint/TwitterCallback.php
@@ -1,0 +1,64 @@
+<?php //phpcs:ignore Wordpress.Files.Filename
+/**
+ * Endpoint for the Twitter OAuth Callback
+ *
+ * @since 0.1.0
+ * @package Smolblog\Social
+ */
+
+namespace Smolblog\Social\Endpoint;
+
+use WebDevStudios\OopsWP\Structure\Content\ApiEndpoint;
+
+/**
+ * Class to register our custom post types
+ *
+ * @since 0.1.0
+ */
+class TwitterCallback extends ApiEndpoint {
+	/**
+	 * Namespace for this endpoint
+	 *
+	 * @since 2019-05-01
+	 * @var   string
+	 */
+	protected $namespace = 'smolblog/v1';
+
+	/**
+	 * Route for this endpoint
+	 *
+	 * @since 2019-05-01
+	 * @var   string
+	 */
+	protected $route = '/twitter/callback';
+
+	/**
+	 * Set up the arguments for this REST endpoint
+	 *
+	 * @author Evan Hildreth <me@eph.me>
+	 * @since 0.1.0
+	 *
+	 * @return array Arguments for the endpoint
+	 */
+	protected function get_args() : array {
+		return [
+			'methods' => [ 'POST' ],
+		];
+	}
+
+	/**
+	 * Execute code for the endpoint
+	 *
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 *
+	 * @param WP_REST_Request $request Current post object.
+	 * @return void used as control structure only.
+	 */
+	public function run( WP_REST_Request $request = null ) {
+		if ( ! $request ) {
+			return;
+		}
+		echo '<pre>' . print_r( $request, true ) . '</pre>';
+	}
+}

--- a/src/Endpoint/TwitterCallback.php
+++ b/src/Endpoint/TwitterCallback.php
@@ -63,7 +63,7 @@ class TwitterCallback extends ApiEndpoint {
 		if ( ! $request ) {
 			return;
 		}
-		$current_user  = get_current_user_id();
+		$current_user  = get_current_user_id(); // TODO: This is not getting the logged in user!
 		$request_token = get_transient( 'smolblog_twitter_oauth_request_' . $current_user );
 
 		if ( isset( $_REQUEST['oauth_token'] ) && $request_token['oauth_token'] !== $_REQUEST['oauth_token'] ) {

--- a/src/Endpoint/TwitterCallback.php
+++ b/src/Endpoint/TwitterCallback.php
@@ -44,8 +44,22 @@ class TwitterCallback extends ApiEndpoint {
 	 */
 	protected function get_args() : array {
 		return [
-			'methods' => [ 'POST', 'GET' ],
+			'methods'             => [ 'POST', 'GET' ],
+			'permission_callback' => [ $this, 'is_user_logged_in' ],
 		];
+	}
+
+	/**
+	 * Check if user is logged in; 'read' permissions are given
+	 * to Subscribers.
+	 *
+	 * @author Evan Hildreth <me@eph.me>
+	 * @since 0.1.0
+	 *
+	 * @return bool If current user has 'read' permissions.
+	 */
+	public function is_user_logged_in() {
+		return current_user_can( 'read' );
 	}
 
 	/**
@@ -63,7 +77,7 @@ class TwitterCallback extends ApiEndpoint {
 		if ( ! $request ) {
 			return;
 		}
-		$current_user  = get_current_user_id(); // TODO: This is not getting the logged in user!
+		$current_user  = get_current_user_id();
 		$request_token = get_transient( 'smolblog_twitter_oauth_request_' . $current_user );
 
 		if ( isset( $_REQUEST['oauth_token'] ) && $request_token['oauth_token'] !== $_REQUEST['oauth_token'] ) {

--- a/src/Endpoint/TwitterCallback.php
+++ b/src/Endpoint/TwitterCallback.php
@@ -59,17 +59,19 @@ class TwitterCallback extends ApiEndpoint {
 		if ( ! $request ) {
 			return;
 		}
-
-		$request_token = get_transient( 'smolblog_twitter_oauth_request_' . get_current_blog_id() );
+		$current_user  = get_current_user_id();
+		$request_token = get_transient( 'smolblog_twitter_oauth_request_' . $current_user );
 
 		if ( isset( $_REQUEST['oauth_token'] ) && $request_token['oauth_token'] !== $_REQUEST['oauth_token'] ) {
-			wp_die( 'OAuth tokens did not match; <a href="/wp-admin/admin.php/smolblog/oauth/init/twitter">try again</a>' );
+			wp_die( 'OAuth tokens did not match; <a href="' . get_rest_url( null, 'smolblog/v1/twitter/init' ) . '">try again</a>' );
 		}
 
-		$connection = new TwitterOAuth( SMOLBLOG_TWITTER_APPLICATION_KEY,
-																		SMOLBLOG_TWITTER_APPLICATION_SECRET,
-																		$request_token['oauth_token'],
-																		$request_token['oauth_token_secret'] );
+		$connection = new TwitterOAuth(
+			SMOLBLOG_TWITTER_APPLICATION_KEY,
+			SMOLBLOG_TWITTER_APPLICATION_SECRET,
+			$request_token['oauth_token'],
+			$request_token['oauth_token_secret']
+		);
 
 		$access_token = $connection->oauth( 'oauth/access_token', [ 'oauth_verifier' => $_REQUEST['oauth_verifier'] ] );
 
@@ -77,5 +79,6 @@ class TwitterCallback extends ApiEndpoint {
 		update_option( 'smolblog_twitter_username', $access_token['screen_name'], false );
 
 		header( 'Location: /wp-admin/admin.php?page=smolblog', true, 302 );
+		die;
 	}
 }

--- a/src/Endpoint/TwitterCallback.php
+++ b/src/Endpoint/TwitterCallback.php
@@ -9,6 +9,8 @@
 namespace Smolblog\Social\Endpoint;
 
 use WebDevStudios\OopsWP\Structure\Content\ApiEndpoint;
+use Abraham\TwitterOAuth\TwitterOAuth;
+use \WP_REST_Request;
 
 /**
  * Class to register our custom post types
@@ -42,7 +44,7 @@ class TwitterCallback extends ApiEndpoint {
 	 */
 	protected function get_args() : array {
 		return [
-			'methods' => [ 'POST' ],
+			'methods' => [ 'POST', 'GET' ],
 		];
 	}
 

--- a/src/Endpoint/TwitterInit.php
+++ b/src/Endpoint/TwitterInit.php
@@ -1,0 +1,75 @@
+<?php //phpcs:ignore Wordpress.Files.Filename
+/**
+ * Endpoint for the Twitter OAuth Init
+ *
+ * @since 0.1.0
+ * @package Smolblog\Social
+ */
+
+namespace Smolblog\Social\Endpoint;
+
+use WebDevStudios\OopsWP\Structure\Content\ApiEndpoint;
+
+/**
+ * Class to register our custom post types
+ *
+ * @since 0.1.0
+ */
+class TwitterInit extends ApiEndpoint {
+	/**
+	 * Namespace for this endpoint
+	 *
+	 * @since 2019-05-01
+	 * @var   string
+	 */
+	protected $namespace = 'smolblog/v1';
+
+	/**
+	 * Route for this endpoint
+	 *
+	 * @since 2019-05-01
+	 * @var   string
+	 */
+	protected $route = '/twitter/init';
+
+	/**
+	 * Set up the arguments for this REST endpoint
+	 *
+	 * @author Evan Hildreth <me@eph.me>
+	 * @since 0.1.0
+	 *
+	 * @return array Arguments for the endpoint
+	 */
+	protected function get_args() : array {
+		return [
+			'methods' => [ 'GET' ],
+		];
+	}
+
+	/**
+	 * Execute code for the endpoint
+	 *
+	 * @since 0.1.0
+	 * @author Evan Hildreth <me@eph.me>
+	 *
+	 * @param WP_REST_Request $request Current post object.
+	 * @return void used as control structure only.
+	 */
+	public function run( WP_REST_Request $request = null ) {
+		if ( ! $request ) {
+			return;
+		}
+
+		$callback_url = 'https://smolblog.local/wp-admin/admin.php/smolblog/oauth/callback/twitter';
+		$connection   = new TwitterOAuth( SMOLBLOG_TWITTER_APPLICATION_KEY, SMOLBLOG_TWITTER_APPLICATION_SECRET );
+
+		$request_token = $connection->oauth( 'oauth/request_token', array( 'oauth_callback' => $callback_url ) );
+
+		set_transient( 'smolblog_twitter_oauth_request_' . get_current_blog_id(), $request_token, 5 * MINUTE_IN_SECONDS );
+
+		$url = $connection->url( 'oauth/authorize', array( 'oauth_token' => $request_token['oauth_token'] ) );
+
+		header( 'Location: ' . $url, true, 302 );
+		die;
+	}
+}

--- a/src/Endpoint/TwitterInit.php
+++ b/src/Endpoint/TwitterInit.php
@@ -9,6 +9,8 @@
 namespace Smolblog\Social\Endpoint;
 
 use WebDevStudios\OopsWP\Structure\Content\ApiEndpoint;
+use Abraham\TwitterOAuth\TwitterOAuth;
+use \WP_REST_Request;
 
 /**
  * Class to register our custom post types

--- a/src/Endpoint/TwitterInit.php
+++ b/src/Endpoint/TwitterInit.php
@@ -44,8 +44,22 @@ class TwitterInit extends ApiEndpoint {
 	 */
 	protected function get_args() : array {
 		return [
-			'methods' => [ 'GET' ],
+			'methods'             => [ 'POST', 'GET' ],
+			'permission_callback' => [ $this, 'is_user_logged_in' ],
 		];
+	}
+
+	/**
+	 * Check if user is logged in; 'read' permissions are given
+	 * to Subscribers.
+	 *
+	 * @author Evan Hildreth <me@eph.me>
+	 * @since 0.1.0
+	 *
+	 * @return bool If current user has 'read' permissions.
+	 */
+	public function is_user_logged_in() {
+		return current_user_can( 'read' );
 	}
 
 	/**
@@ -63,7 +77,7 @@ class TwitterInit extends ApiEndpoint {
 		}
 
 		$current_user = get_current_user_id();
-		$callback_url = get_rest_url( null, 'smolblog/v1/twitter/callback' );
+		$callback_url = get_rest_url( null, 'smolblog/v1/twitter/callback' ) . '?_wpnonce=' . wp_create_nonce( 'wp_rest' );
 		$connection   = new TwitterOAuth( SMOLBLOG_TWITTER_APPLICATION_KEY, SMOLBLOG_TWITTER_APPLICATION_SECRET );
 
 		$request_token = $connection->oauth( 'oauth/request_token', array( 'oauth_callback' => $callback_url ) );

--- a/src/Endpoint/TwitterInit.php
+++ b/src/Endpoint/TwitterInit.php
@@ -60,12 +60,13 @@ class TwitterInit extends ApiEndpoint {
 			return;
 		}
 
-		$callback_url = 'https://smolblog.local/wp-admin/admin.php/smolblog/oauth/callback/twitter';
+		$current_user = get_current_user_id();
+		$callback_url = get_rest_url( null, 'smolblog/v1/twitter/callback' );
 		$connection   = new TwitterOAuth( SMOLBLOG_TWITTER_APPLICATION_KEY, SMOLBLOG_TWITTER_APPLICATION_SECRET );
 
 		$request_token = $connection->oauth( 'oauth/request_token', array( 'oauth_callback' => $callback_url ) );
 
-		set_transient( 'smolblog_twitter_oauth_request_' . get_current_blog_id(), $request_token, 5 * MINUTE_IN_SECONDS );
+		set_transient( 'smolblog_twitter_oauth_request_' . $current_user, $request_token, 5 * MINUTE_IN_SECONDS );
 
 		$url = $connection->url( 'oauth/authorize', array( 'oauth_token' => $request_token['oauth_token'] ) );
 

--- a/src/SmolblogSocial.php
+++ b/src/SmolblogSocial.php
@@ -39,5 +39,6 @@ class SmolblogSocial extends Plugin {
 	 */
 	protected $services = [
 		Endpoint\EndpointRegistrar::class,
+		AdminPage\AdminPageRegistrar::class,
 	];
 }

--- a/src/SmolblogSocial.php
+++ b/src/SmolblogSocial.php
@@ -1,4 +1,4 @@
-<?php
+<?php //phpcs:ignore Wordpress.Files.Filename
 /**
  * The main class file.
  *
@@ -38,24 +38,6 @@ class SmolblogSocial extends Plugin {
 	 * @since 0.1.0
 	 */
 	protected $services = [
+		Endpoint\EndpointRegistrar::class,
 	];
-
-	/**
-	 * Register this plugin's services.
-	 *
-	 * Note: in standard implementations, there's no need to declare this function inside of your main plugin file,
-	 * as it gets called automatically by the parent ServiceRegistrar class.
-	 *
-	 * That said, in your custom implementation, it's possible you might be using something like a Dependency Injection
-	 * container in order to create your Service classes. Those Services might have parameters in their constructors,
-	 * or there may just be something else necessary for you to process at the time the services get registered. As
-	 * such, the `register_services` method has protected visibility so you can define that customization here. We've
-	 * extended the method here primarily for demonstration purposes to let you know that it is possible.
-	 *
-	 * @author Evan Hildreth <me@eph.me>
-	 * @since  0.1.0
-	 */
-	protected function register_services() { // phpcs:ignore
-		parent::register_services();
-	}
 }


### PR DESCRIPTION
Closes #1 

### DESCRIPTION ###
- Integrate with Twitter OAuth
- Store credentials on a per-account basis:
  - WP accounts have a one-to-many with Twitter accounts
- Sets up custom table to store credentials

### SCREENSHOTS ###

https://eph.me/3

### STEPS TO VERIFY ###
1. Install the plugin
2. Verify that the Smolblog page shows.
3. On the page, verify that a twitter account can be linked.
4. Verify that a user with Subscriber privileges can also see the page and link an account.